### PR TITLE
Morph: add more tags

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,6 +9,37 @@ metadata:
     - template
     - nodejs
     - express
+    - microservice
+    - rest-api
+    - database
+    - mongodb
+    - postgresql
+    - docker
+    - kubernetes
+    - ci-cd
+    - testing
+    - jest
+    - eslint
+    - prettier
+    - swagger
+    - authentication
+    - authorization
+    - logging
+    - monitoring
+    - metrics
+    - health-check
+    - cors
+    - validation
+    - middleware
+    - async
+    - promises
+    - error-handling
+    - security
+    - rate-limiting
+    - caching
+    - redis
+    - api-gateway
+    - json
 spec:
   type: service
   lifecycle: production


### PR DESCRIPTION
This PR contains the following modifications:

- AI (anthropic/claude-sonnet-4-5-20250929):
can you add like 30 more random tags to the catalog info
 (Slicing enabled: Yes)

Generated by [Morph](https://codemorph.dev)